### PR TITLE
Fix broken Techopedia link in Module 2 – Understanding Subnets

### DIFF
--- a/docs/module-02/index.html
+++ b/docs/module-02/index.html
@@ -61,7 +61,7 @@
 <h4 id="preparation-material">Preparation Material</h4>
 <p>Please review the following:</p>
 <p><a href="https://calculator.aws/" target="_blank">AWS Pricing Calculator</a></p>
-<p><a href="https://www.techopedia.com/6/28587/internet/8-steps-to-understanding-ip-subnetting" target="_blank">Understanding Subnets</a></p>
+<p><a href="https://www.techopedia.com/8-steps-to-understanding-ip-subnetting" target="_blank">Understanding Subnets</a></p>
 <p><a href="https://www.geeksforgeeks.org/tcp-ip-ports-and-its-applications/" target="_blank">Ports and TCP/IP</a></p>
 <h4 id="aws-lab">AWS Lab</h4>
 <ul>

--- a/source/module-02/index.md
+++ b/source/module-02/index.md
@@ -17,7 +17,7 @@ Please review the following:
 
 [AWS Pricing Calculator](https://calculator.aws/){:target="_blank"}
 
-[Understanding Subnets](https://www.techopedia.com/6/28587/internet/8-steps-to-understanding-ip-subnetting){:target="_blank"}
+[Understanding Subnets](https://www.techopedia.com/8-steps-to-understanding-ip-subnetting){:target="_blank"}
 
 [Ports and TCP/IP](https://www.geeksforgeeks.org/tcp-ip-ports-and-its-applications/){:target="_blank"}
 


### PR DESCRIPTION
Replaced outdated/broken link in the "Preparation Material (Cloud Economics and Billing)" section of Module 2 with a valid Techopedia article: "8 Steps to Understanding IP Subnetting" (https://www.techopedia.com/8-steps-to-understanding-ip-subnetting).

This fix addresses a student-reported issue—thanks to Kaylee Wright for catching it during this pilot run. Notifying students via announcement while awaiting course lead approval.